### PR TITLE
fix: display correct env for prerender

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY . .
 RUN bun install
 
 FROM base AS build
+ARG BRANCH
+ENV NUXT_PUBLIC_BRANCH=${BRANCH}
 ENV NODE_ENV=production
 RUN --mount=type=secret,id=gh_token \
     NUXT_GH_API_TOKEN="$(cat /run/secrets/gh_token)" bun run -b build
@@ -17,4 +19,4 @@ ARG BRANCH
 ENV NUXT_PUBLIC_BRANCH=${BRANCH}
 ENV HOST=0.0.0.0
 EXPOSE 3000/tcp
-ENTRYPOINT [ "sh", "-c",  "export NUXT_PUBLIC_BUNVER=$(bun -v) && bun -b run .output/server/index.mjs" ]
+ENTRYPOINT [ "sh", "-c",  "NUXT_PUBLIC_BUNVER=$(bun -v) && bun -b run .output/server/index.mjs" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ARG BRANCH
 ENV NUXT_PUBLIC_BRANCH=${BRANCH}
 ENV HOST=0.0.0.0
 EXPOSE 3000/tcp
-ENTRYPOINT [ "sh", "-c",  "NUXT_PUBLIC_BUNVER=$(bun -v) && bun -b run .output/server/index.mjs" ]
+ENTRYPOINT [ "sh", "-c",  "NUXT_PUBLIC_BUNVER=$(bun -v) bun -b run .output/server/index.mjs" ]

--- a/app/components/app/Footer.vue
+++ b/app/components/app/Footer.vue
@@ -2,7 +2,7 @@
 import { version } from "nuxt/package.json"
 
 const { t } = useI18n()
-const { public: { branch, bunver } } = useRuntimeConfig()
+const config = useRuntimeConfig()
 const isHome = useRoute().path === "/en" || useRoute().path === "/ru"
 
 const variantKey = useState("variantKey", () => {
@@ -26,8 +26,8 @@ const variantIcons = {
     <div>
       <p leading="loose">
         <span u-text="inherit"><span font="head">rogi#su</span> [<a
-          :href="`https://github.com/27rogi/website/commit/${branch}`" target="_blank"
-        ><span class="colorful">{{ branch }}</span>
+          :href="`https://github.com/27rogi/website/commit/${config.public.branch}`" target="_blank"
+        ><span class="colorful">{{ config.public.branch }}</span>
         </a>]
           <Icon name="ph:copyright-bold" relative top="0.1rem" size="1em" /> {{ new Date().getFullYear() }}
         </span>
@@ -42,7 +42,9 @@ const variantIcons = {
           </template>
         </template>
         <template #versions>
-          <span class="colorful"><Icon name="devicon:nuxt" relative top="0.1rem" size="1.2em" /> Nuxt {{ version }} | <Icon name="devicon:bun" relative top="0.1rem" size="1.2em" /> {{ bunver !== "" ? `Bun ${bunver}` : "Bun not detected ⚠️" }}</span>
+          <ClientOnly>
+            <span class="colorful"><Icon name="devicon:nuxt" relative top="0.1rem" size="1.2em" /> Nuxt {{ version }} | <Icon name="devicon:bun" relative top="0.1rem" size="1.2em" /> {{ config.public.bunver !== "" ? `Bun ${config.public.bunver}` : "Bun not detected ⚠️" }}</span>
+          </ClientOnly>
         </template>
       </i18n-t>
     </div>

--- a/bun.lock
+++ b/bun.lock
@@ -25,8 +25,10 @@
       "devDependencies": {
         "@antfu/eslint-config": "^8.1.1",
         "@iconify-json/devicon": "^1.2.62",
+        "@iconify-json/file-icons": "^1.2.2",
         "@iconify-json/mdi": "^1.2.3",
         "@iconify-json/ph": "^1.2.2",
+        "@iconify-json/simple-icons": "^1.2.78",
         "@iconify-json/vscode-icons": "^1.2.45",
         "@nuxt/devtools": "^4.0.0-alpha.4",
         "@nuxt/eslint": "^1.15.2",
@@ -284,9 +286,13 @@
 
     "@iconify-json/devicon": ["@iconify-json/devicon@1.2.62", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-X0o0+fOJL2t5JTbDCGLRzrmvf8Pv5q8dr86+fW+F/VJ9qvXTtny6lqGIwjE9AY4VTLm3i8f/N+VtRheSW6OkEg=="],
 
+    "@iconify-json/file-icons": ["@iconify-json/file-icons@1.2.2", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-ajk44wYGTiu79EAyrfNHNaxZ1/2Z1xuSOAvYUT/pAPWHc+P6n9TUZP/ccnPG18kx0WMBxmkHHQ9/zkm6ENhk+Q=="],
+
     "@iconify-json/mdi": ["@iconify-json/mdi@1.2.3", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg=="],
 
     "@iconify-json/ph": ["@iconify-json/ph@1.2.2", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.78", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ=="],
 
     "@iconify-json/vscode-icons": ["@iconify-json/vscode-icons@1.2.45", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-ow+ueibMIq79ueM1kv6cOWgHx8jfh1XJQi2RrqMHb4HLbvIBlxpy5PCMvOJXlA68R6fBAHpWQeh6uWx7VKEVsA=="],
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
     ghApiBase: "https://api.github.com",
     ghApiToken: "",
     public: {
-      branch: "v3",
+      branch: "v4",
       bunver: "",
     },
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,10 @@
   "devDependencies": {
     "@antfu/eslint-config": "^8.1.1",
     "@iconify-json/devicon": "^1.2.62",
+    "@iconify-json/file-icons": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
     "@iconify-json/ph": "^1.2.2",
+    "@iconify-json/simple-icons": "^1.2.78",
     "@iconify-json/vscode-icons": "^1.2.45",
     "@nuxt/devtools": "^4.0.0-alpha.4",
     "@nuxt/eslint": "^1.15.2",


### PR DESCRIPTION
in latest update with correct page prerendering there's an issue with env args not being displayed even when passed, trying to use clientside to avoid prerendering it and adding branch env in dockerfile build to make it permanently embeded